### PR TITLE
Added new way to call check_func

### DIFF
--- a/AutoFeedback/__init__.py
+++ b/AutoFeedback/__init__.py
@@ -1,3 +1,7 @@
-
 from . import _version
 __version__ = _version.get_versions()['version']
+
+
+from AutoFeedback.plotchecks import check_plot
+from AutoFeedback.varchecks import check_vars
+from AutoFeedback.funcchecks import check_func

--- a/AutoFeedback/function_error_messages.py
+++ b/AutoFeedback/function_error_messages.py
@@ -26,7 +26,7 @@ def _input_error(funcname, numargs):
     return e_message
 
 
-def _value_error(funcname, inp,  exp, res):
+def _value_error(funcname, inp, exp, res):
     e_message = f"""The function {funcname} returns the wrong value(s).
     When executed with the input(s), {inp}, we expected the output, {exp}, but
     instead we got {res}.

--- a/AutoFeedback/plotchecks.py
+++ b/AutoFeedback/plotchecks.py
@@ -120,7 +120,7 @@ def _check_patchdata(patch, exppatch):
     for p in patch:
         xd, yd = p.get_xy()
         yd = p.get_height()
-        x.append(xd + 0.5*p.get_width())
+        x.append(xd + 0.5 * p.get_width())
         y.append(yd)
     return exppatch.check_linedata(x, y)
 
@@ -154,9 +154,9 @@ def _e_string(error, label):
     and the label of the object at fault. E.G data_('xyline')
     """
     if label:
-        return error+'("'+label+'")'
+        return f'{error}("{label}")'
     else:
-        return error+"('')"
+        return f"{error}('')"
 
 
 def check_plot(explines, exppatch=None, explabels=None, expaxes=None,

--- a/AutoFeedback/plotclass.py
+++ b/AutoFeedback/plotclass.py
@@ -102,21 +102,22 @@ class line:
             label for the data set to be plotted
         """
         if self.diagnosis == "badxy":
-            error_message = plot_error_messages.error_message._data(label)
+            emsg = plot_error_messages.error_message()
+            error_message = emsg._data(label)
         elif self.diagnosis == "badx":
             if hasattr(self.xdata, "get_error") and\
                     callable(self.xdata.get_error):
                 error_message = self.xdata.get_error(
-                    "x coordinates of the data series in the graph labelled "
-                    + label)
+                    f"""x coordinates of the data series in the graph labelled
+{label}""")
             else:
                 error_message = self.generic_error(label, "x")
         elif self.diagnosis == "bady":
             if hasattr(self.ydata, "get_error") and\
                     callable(self.ydata.get_error):
                 error_message = self.ydata.get_error(
-                    "y coordinates of the data series in the graph labelled "
-                    + label)
+                    f"""y coordinates of the data series in the graph labelled
+{label}""")
             else:
                 error_message = self.generic_error(label, "y")
         return error_message

--- a/AutoFeedback/randomclass.py
+++ b/AutoFeedback/randomclass.py
@@ -128,7 +128,7 @@ class randomvar:
         from scipy.stats import norm
         if self.limit <= 0:
             raise RuntimeError("limit needs to be to do this task set")
-        return (value / norm.ppf((1+self.limit)/2))**2
+        return (value / norm.ppf((1 + self.limit) / 2))**2
 
     def _get_statistic(self, value, expectation, variance, number):
         """calculate the test statistic
@@ -148,13 +148,13 @@ class randomvar:
             from math import sqrt
             if variance < 0:
                 RuntimeError("invalid")
-            return (value - expectation) / sqrt(variance/number)
+            return (value - expectation) / sqrt(variance / number)
         elif self.distribution == "chi2":
             if self.dof <= 0:
                 raise RuntimeError(
                     """if running chi2 test the number of degrees of
 freedom needs to be set""")
-            return self.dof*value / variance
+            return self.dof * value / variance
         return 1
 
     def _hypo_check(self, stat):
@@ -171,9 +171,9 @@ freedom needs to be set""")
         if self.distribution == "normal":
             from scipy.stats import norm
             if stat > 0:
-                pval = 2*norm.cdf(-stat)
+                pval = 2 * norm.cdf(-stat)
             else:
-                pval = 2*norm.cdf(stat)
+                pval = 2 * norm.cdf(stat)
         elif self.distribution == "chi2":
             if self.dof <= 0:
                 raise RuntimeError(
@@ -182,7 +182,7 @@ needs to be set""")
             from scipy.stats import chi2
             pval = chi2.cdf(stat, self.dof)
             if pval > 0.5:
-                pval = 1-chi2.cdf(stat, self.dof)
+                pval = 1 - chi2.cdf(stat, self.dof)
         else:
             return False
 
@@ -213,12 +213,12 @@ needs to be set""")
             # Now check the limits
             self.distribution = "chi2"
             if not self._check_random_var(self._confToVariance(
-                    val[1]-val[0]), -1):
+                    val[1] - val[0]), -1):
                 self.distribution = "conf_lim"
                 self.output_component = "lower confidence limit from the "
                 return False
             if not self._check_random_var(self._confToVariance(
-                    val[2]-val[1]), -1):
+                    val[2] - val[1]), -1):
                 self.distribution = "conf_lim"
                 self.output_component = "upper confidence limit from the "
                 return False
@@ -300,13 +300,14 @@ needs to be set""")
                 return True
             else:
                 # Check on expectation
-                mean = sum(val)/len(val)
+                mean = sum(val) / len(val)
                 var = self.variance
                 if self.variance == 0:
                     S2 = 0
                     for v in val:
-                        S2 = S2 + v*v
-                    var = (len(val)/(len(val)-1))*(S2/len(val) - mean*mean)
+                        S2 = S2 + v * v
+                    var = (len(val) / (len(val) - 1)) * \
+                        (S2 / len(val) - mean * mean)
                 stat = self._get_statistic(
                     mean, self.expectation,
                     var, len(val))
@@ -317,8 +318,8 @@ needs to be set""")
                 # Now check on variance
                 self.distribution, S2, self.dof = "chi2", 0, len(val) - 1
                 for v in val:
-                    S2 = S2 + v*v
-                var = (len(val) / self.dof)*(S2 / len(val) - mean*mean)
+                    S2 = S2 + v * v
+                var = (len(val) / self.dof) * (S2 / len(val) - mean * mean)
                 stat = self._get_statistic(
                     var, self.expectation,
                     self.variance, len(val))
@@ -334,10 +335,10 @@ needs to be set""")
 
             if num < 0:
                 stat = self._get_statistic(
-                    vv,  self.expectation, self.variance, 1)
+                    vv, self.expectation, self.variance, 1)
             else:
                 stat = self._get_statistic(
-                    vv,  self.expectation[num], self.variance[num], 1)
+                    vv, self.expectation[num], self.variance[num], 1)
 
         return self._hypo_check(stat)
 

--- a/AutoFeedback/varchecks.py
+++ b/AutoFeedback/varchecks.py
@@ -64,13 +64,13 @@ def check_value(a, b):
     if (isinstance(a, str) and isinstance(b, str)) \
             or (isinstance(a, dict) and isinstance(b, dict)):
         return (a == b)
-    elif (sym_installed and isinstance(a, sp.Basic) and
-          isinstance(b, sp.Basic)):
+    elif (sym_installed and isinstance(a, sp.Basic)
+          and isinstance(b, sp.Basic)):
         try:
             sp.simplify(a)
             sp.simplify(b)
-            return (sp.simplify(a) == sp.simplify(b) or
-                    (sp.factor(a) == sp.factor(b)))
+            return (sp.simplify(a) == sp.simplify(b)
+                    or (sp.factor(a) == sp.factor(b)))
         except Exception:
             return (a == b)
     else:

--- a/AutoFeedback/variable_error_messages.py
+++ b/AutoFeedback/variable_error_messages.py
@@ -115,7 +115,7 @@ def output_check(expected, executable="main.py"):
     out = run([sys.executable, executable])
     screen_out = str(out).split("'")[1]
 
-    check = screen_out == expected+"\\n"
+    check = screen_out == expected + "\\n"
 
     errmsg = """The text printed to screen is not correct. Ensure you have
         printed the correct variables, in the correct order,

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -4,11 +4,11 @@
 Usage
 =====
 
-Start by importing AutoFeedback.
+AutoFeedback offers three high-level functions for checking student code
 
 .. code-block:: python
 
-    import AutoFeedback
+    from AutoFeedback import check_vars, check_func, check_plot
 
 Then use one of the three high level functions available for checking student
 code.
@@ -16,11 +16,10 @@ code.
 Checking Variables
 ==================
 
-:py:meth:`AutoFeedback.varchecks.check_vars`
+:py:meth:`AutoFeedback.check_vars`
 
 .. code-block:: python
 
-   from AutoFeedback.varchecks import check_vars
    assert check_vars('x', 3)
 
 will check whether the student has defined a variable `x` in main.py to be equal to 3 and
@@ -29,11 +28,40 @@ print feedback to the screen.
 Checking Functions
 ==================
 
-:py:meth:`AutoFeedback.funcchecks.check_func`
+:py:meth:`AutoFeedback.check_func`
+
+There are two ways to use `check_func`. The first is to define the functions exactly as you
+wish the students to do. You should also set the `.inputs` attribute of each
+function as a list of tuples containing some sample inputs that can be used for
+testing the function:
+
+.. code-block:: python
+   
+   def addup(x, y):
+      return x+y
+   addup.inputs = [(3, 4), (5, 6)]
+
+   def addAndSquare(x, y):
+      z = addup(x, y) 
+      return z * z
+   addAndSquare.inputs = [(3, 4)]
+
+   assert check_func(addup)
+   assert check_func(addAndSquare, calls=['addup'])
+
+Although this requires more lines of code than the legacy usage (see below), it
+removes the need to pre-calculate the expected outputs, ensuring that
+the results are robust against changes to libraries, environments etc.
+
+Legacy usage
+------------
+
+The second method is to pass the function name as a string. This is maintained
+for backwards compatability. In this case the inputs and expected outputs must
+be passed:
 
 .. code-block:: python
 
-   from AutoFeedback.func_checks import check_funcs
    assert check_func('addup', inputs=[(3, 4), (5, 6)], expected=[7, 11])
 
 will check whether the student has defined a function named addup `addup` in main.py which takes two input arguments, adds them and returns the result. 
@@ -43,16 +71,16 @@ argument:
 
 .. code-block:: python
 
-   assert check_func('addAndMult', inputs=[(3, 4)], expected=[84], calls=['addup'])
+   assert check_func('addAndSquare', inputs=[(3, 4)], expected=[49], calls=['addup'])
 
-which checks whether the function `addAndMult` calls the function `addup` during
+which checks whether the function `addAndSquare` calls the function `addup` during
 its execution.
 
 
 Checking Plots
 ==============
 
-:py:meth:`AutoFeedback.plotchecks.check_plot`
+:py:meth:`AutoFeedback.check_plot`
 
 To check a student's plot object you must first define the 'lines' you expect to
 see in the plot. The lines are of type :py:meth:`AutoFeedback.plotclass.line`
@@ -62,7 +90,6 @@ and are defined and tested as follows:
 .. code-block:: python
 
    from AutoFeedback.plotclass import line
-   from AutoFeedback.plotchecks import check_plot
    line1 = line([0,1,2,3], [0,1,4,9],
                 linestyle=['-', 'solid'],
                 colour=['r', 'red', (1.0,0.0,0.0,1)],
@@ -209,7 +236,6 @@ following assert statement in a test:
 
 .. code:: python
 
-   from AutoFeedback.funcchecks import check_func
    from AutoFeedback.randomclass import randomvar
 
    # We will test the students code by generating a Bernoulli random variable with p=0.5
@@ -234,7 +260,6 @@ following assert statement in a test:
 
 .. code:: python
 
-   from AutoFeedback.funcchecks import check_func
    from AutoFeedback.randomclass import randomvar
 
    # We will test the students code by generating a Bernoulli random variable with p=0.5
@@ -275,7 +300,6 @@ We can thus use AutoFeedback to test the students code by writing:
 
 .. code:: python
 
-   from AutoFeedback.funcchecks import check_func
    from AutoFeedback.randomclass import randomvar
 
    # We are going to test for a sample mean computed from 100 normal random variables here
@@ -308,7 +332,6 @@ following code:
 
 ::
 
-   from AutoFeedback.funcchecks import check_func
    from AutoFeedback.randomclass import randomvar
 
    # We are going to test for a sample mean computed from 100 normal random variables here
@@ -348,7 +371,6 @@ chi2 test. To test the function above you can thus write:
 
 .. code:: python
 
-   from AutoFeedback.funcchecks import check_func
    from AutoFeedback.randomclass import randomvar
 
    # We are going to test for a sample mean computed from 100 normal random variables here
@@ -606,7 +628,6 @@ this:
 
 .. code:: python
 
-   from AutoFeedback.funcchecks import check_func
    from AutoFeedback.randomclass import randomvar
 
    # We are using 100 random variables to calculate our sample mean here
@@ -658,7 +679,6 @@ To test this function using AutoFeedback you would write:
 
 .. code:: python
 
-   from AutoFeedback.funcchecks import check_func
    from AutoFeedback.randomclass import randomvar
 
    # We are using 100 random variables to calculate our sample mean here

--- a/main.py
+++ b/main.py
@@ -13,6 +13,8 @@ def f1(x):
 def f2(x, y):
     return
 
+def broken_function(x):
+    raise RuntimeError
 
 x = 3
 y = np.linspace(0, 1, 3)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 scipy
+multipledispatch

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,13 @@ omit =
     setup.py
     versioneer.py
     */__init__.py
+    test/*.py
+[flake8]
+extend-ignore =
+    W503
+per-file-ignores =
+    # imported but unused
+    AutoFeedback/__init__.py: F401
+    # multiply defined function (using multipledispatch)
+    AutoFeedback/funcchecks.py: F811
+    

--- a/test/testfuncs.py
+++ b/test/testfuncs.py
@@ -8,12 +8,13 @@ def f2(x):
     return
 
 
-def f4(x):
+def f1(x):
     return x**2
+f1.inputs = [(1,), (2,), (3,)]
 
 
 def f3(x, y):
-    return(np.sqrt(f4(x)))
+    return(np.sqrt(f1(x)))
 
 
 class UnitTests(unittest.TestCase):
@@ -24,7 +25,7 @@ class UnitTests(unittest.TestCase):
         assert(not fc._exists('f3'))
 
     def test_1input_vars(self):
-        assert(fc._input_vars(f4, 10))
+        assert(fc._input_vars(f1, 10))
 
     def test_2input_vars(self):
         assert(fc._input_vars(f3, (10, 11)))
@@ -33,7 +34,7 @@ class UnitTests(unittest.TestCase):
         assert(not fc._input_vars(f3, (10, 11, 12)))
 
     def test_not2input_vars(self):
-        assert(not fc._input_vars(f4, (10, 11)))
+        assert(not fc._input_vars(f1, (10, 11)))
 
     def test_returns(self):
         assert(fc._returns(f3, (10, 11)))
@@ -42,25 +43,58 @@ class UnitTests(unittest.TestCase):
         assert(not fc._returns(f2, (10)))
 
     def test_check_outputs(self):
-        assert(fc._check_outputs(f4, (4,), 16))
+        assert(fc._check_outputs(f1, (4,), 16))
 
     def test_2check_outputs(self):
-        assert(fc._check_outputs(f4, (-10,), 100))
+        assert(fc._check_outputs(f1, (-10,), 100))
 
     def test_array_check_outputs(self):
-        assert(fc._check_outputs(f4, (np.array([1, 2, 3]),), [1, 4, 9]))
+        assert(fc._check_outputs(f1, (np.array([1, 2, 3]),), [1, 4, 9]))
 
     def test_notcheck_outputs1(self):
-        assert(not fc._check_outputs(f4, (3,), 10))
+        assert(not fc._check_outputs(f1, (3,), 10))
 
     def test_notcheck_outputs2(self):
         assert(not fc._check_outputs(f3, (10, 11), 9))
 
     def test_calls(self):
-        assert(fc._check_calls(f3, 'f4'))
+        assert(fc._check_calls(f3, 'f1'))
 
     def test_notcalls(self):
-        assert(not fc._check_calls(f3, 'f1'))
+        assert(not fc._check_calls(f3, 'f4'))
+
+    def test_returnlist(self):
+        def fretlist(x):
+            return (1, 2)
+        assert fc._returns(fretlist, (1,))
+
+    def test_return_exception(self):
+        def raise_exc(x):
+            raise TypeError
+        with self.assertRaises(Exception):
+            fc._returns(raise_exc, (1,))
+
+    def test_nsamples_error(self):
+        a = f3
+        a.check_value = f1
+        with self.assertRaises(RuntimeError) as context:
+            fc._check_outputs(f1, (1,), a)
+        assert "there should be an attribute" in str(context.exception)
+
+    def test_nsamples_return(self):
+        def retlist(a):
+            return a
+        a = f3
+        a.check_value = retlist
+        a.nsamples = 2
+        y = fc._check_outputs(f1, (1,), a)
+        assert y == [1, 1]
+
+    def test_nsamples_exception(self):
+        a = f3
+        a.check_value = f1
+        a.nsamples = 2
+        assert not fc._check_outputs(f1, (1,), a)
 
 
 class SystemTests(unittest.TestCase):
@@ -69,3 +103,29 @@ class SystemTests(unittest.TestCase):
                               output=False) and
                 not fc.check_func('f2', [(3,), (-4,)], [9, 16],
                                   output=False))
+
+    def test_f1_handle(self):
+        assert (fc.check_func(f1, inputs=[(3,), (-4,)], output=False))
+
+    def test_f1_inputs(self):
+        assert (fc.check_func(f1, output=False))
+
+    def test_inputerror(self):
+        with self.assertRaises(Exception) as context:
+            fc.check_func(f2)
+
+        assert ('check_func with a function handle' in str(context.exception))
+
+    def test_string_inputerror(self):
+        with self.assertRaises(Exception) as context:
+            fc.check_func('f2')
+
+        assert ('check_func with a function name' in str(context.exception))
+
+    def test_runtime_exception(self):
+        import io
+        import contextlib
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            fc.check_func('broken_function', [(1,)], [1])
+        assert 'The function broken_function does not' in f.getvalue()

--- a/test/testplotclass.py
+++ b/test/testplotclass.py
@@ -1,0 +1,69 @@
+import unittest
+from AutoFeedback.plotclass import line
+
+line1 = line([0, 1], [0, 1], label="xdata")
+
+
+class UnitTests(unittest.TestCase):
+    def test_generic_error(self):
+        expected = """The giggle-coordinates of the points in the data set
+google are incorrect
+
+       The instructions in the README file explain the specific values
+       for the coordinates of the points in your graph.
+       Make sure you have read those instructions carefully and that you
+       know what the coordinates of the points in your graph should be"""
+        assert line1.generic_error("google", "giggle") == expected
+
+    def test_get_badxy(self):
+        line1.diagnosis = "badxy"
+        expected = """Data set google is plotted with incorrect data.
+    Check that all variables are correctly defined, and that you are plotting
+    the right variables in the right order (i.e. plt.plot(X,Y))"""
+        assert line1.get_error("google") == expected
+
+    def test_get_badx_get_error(self):
+        class dummy_xdata:
+            self.data = [0, 1]
+            def get_error(self, emsg):
+                return emsg
+        line2 = line([0, 1], [0, 1], label="xdata")
+        line2.diagnosis = "badx"
+        line2.xdata = dummy_xdata()
+        expected = """x coordinates of the data series in the graph labelled
+googly"""
+        assert line2.get_error("googly") == expected
+
+    def test_badx_generic_error(self):
+        line1.diagnosis = "badx"
+        expected = """The x-coordinates of the points in the data set
+google are incorrect
+
+       The instructions in the README file explain the specific values
+       for the coordinates of the points in your graph.
+       Make sure you have read those instructions carefully and that you
+       know what the coordinates of the points in your graph should be"""
+        assert line1.get_error("google") == expected
+
+    def test_get_bady_get_error(self):
+        class dummy_ydata:
+            self.data = [0, 1]
+            def get_error(self, emsg):
+                return emsg
+        line2 = line([0, 1], [0, 1], label="xdata")
+        line2.diagnosis = "bady"
+        line2.ydata = dummy_ydata()
+        expected = """y coordinates of the data series in the graph labelled
+googly"""
+        assert line2.get_error("googly") == expected
+
+    def test_bady_generic_error(self):
+        line1.diagnosis = "bady"
+        expected = """The y-coordinates of the points in the data set
+google are incorrect
+
+       The instructions in the README file explain the specific values
+       for the coordinates of the points in your graph.
+       Make sure you have read those instructions carefully and that you
+       know what the coordinates of the points in your graph should be"""
+        assert line1.get_error("google") == expected


### PR DESCRIPTION
Several changes

1. Raised the high level functions to package level in `__init__.py` meaning that now one can simply import as follows

      from AutoFeedback import check_vars, check_func, check_plot

   rather than having to import from the modules `varchecks`, `funcchecks` and `plotchecks`.

2. Added the possibility to call `check_func` with a function handle. This means one can call in the following way:

```python
      def addup(x, y):
         return x+y
      addup.inputs = [(3, 4), (5, 6)]

      def addAndSquare(x, y):
         z = addup(x, y)
         return z * z
      addAndSquare.inputs = [(3, 4)]

      assert check_func(addup)
      assert check_func(addAndSquare, calls=['addup'])
```

   i.e. `check_func` will use the functions you have defined to generate the expected outputs. This, in principle, makes `check_func` slightly more robust against changes to libraries, and against errors in typing in expected outputs. The old way of calling still works though.

3. New tests added to improve test coverage.