### PR TITLE
Fixed failing tests of randomvars with pvalues

### DIFF
--- a/AutoFeedback/funcchecks.py
+++ b/AutoFeedback/funcchecks.py
@@ -64,6 +64,7 @@ nsamples in the class you have provided as reference""")
                 res = expected.nsamples * [0]
                 for i in range(expected.nsamples):
                     res[i] = func(*inputs)
+
             return expected.check_value(res)
         else:
             res = func(*inputs)
@@ -131,17 +132,21 @@ def _run_all_checks(funcname, inputs, expected, calls=[], output=True):
 
         assert (_returns(func, inputs[0])), "return"
         listOfOuts = []
-        minPval = 1
+        PvalList = []
         for ins, outs in zip(inputs, expected):
             res = func(*copy(ins))  # ensure the inputs are not overwritten
             if isinstance(expected[0], randomvar):
                 listOfOuts.append(_check_outputs(func, ins, outs))
-                minPval = min(minPval, outs.pval)
+                PvalList.append(outs.pval)
             else:
                 assert _check_outputs(func, ins, outs), "outputs"
         if isinstance(expected[0], randomvar):
-            outs.pval = minPval
-            assert listOfOuts.count(False)/len(listOfOuts) < 0.5, "outputs"
+            success = listOfOuts.count(False)/len(listOfOuts) < 0.5
+            if not success:
+                outs.pval = min(PvalList)
+            else:
+                outs.pval = max(PvalList)
+            assert success, "outputs"
 
         for call in calls:
             assert (_check_calls(func, call)), "calls"

--- a/AutoFeedback/function_error_messages.py
+++ b/AutoFeedback/function_error_messages.py
@@ -112,7 +112,8 @@ def print_error_message(error, funcname, inp=(0,), exp=7, result=0,
             error = "outputs"
         else:
             error = "success"
-            pval_string = f" The p-value is {exp.pval}."
+            pval_string = f"""
+The p-value for the hypothesis test on your random variable is {exp.pval}."""
 
     if (str(error) == "success"):
         print(f"{bcolors.OKGREEN}Function, {funcname} is correct!{pval_string}\
@@ -126,8 +127,8 @@ def print_error_message(error, funcname, inp=(0,), exp=7, result=0,
         elif (str(error) == "outputs"):
             if hasattr(exp, "get_error") and callable(exp.get_error):
                 emsg = exp.get_error(
-                    f"values returned from the function {funcname} with input\
-                    parameters {inp}")
+                    f"""values returned from the function {funcname} with input
+parameters {inp}""")
             else:
                 emsg = _value_error(funcname, inp, exp, result)
         elif (str(error) == "return"):

--- a/AutoFeedback/randomclass.py
+++ b/AutoFeedback/randomclass.py
@@ -52,6 +52,7 @@ class randomvar:
         self.limit = limit
         self.transform = transform
         self.nsamples = nsamples
+        self.pval = 0
         if limit > 0 and dist == "chi2":
             if self.transform is not None:
                 raise RuntimeError(

--- a/AutoFeedback/variable_error_messages.py
+++ b/AutoFeedback/variable_error_messages.py
@@ -68,7 +68,8 @@ def print_error_message(error, varname, exp, res):
             error = "value"
         else:
             error = "success"
-            pval_string = f" The p-value is {exp.pval}."
+            pval_string = f"""The p-value for the hypothesis test on your
+random variable is {exp.pval}."""
 
     if (str(error) == "success"):
         print(f"{bcolors.OKGREEN}Variable {varname} is correct!{pval_string}\


### PR DESCRIPTION
When testing functions that produce random variables, the function is called multiple times, and the p-value is calculated in order to determine if the random variable satisfies a hypothesis test.

Previously, we stored only the minimum p-value obtained, meaning that even if 99 out of 100 calls gave satisfactory answers, the printed the minimum p-value (<0.05) and implied that the function was incorrect.

This has now been amended- we record how many of the p-values are < 0.05, and if this falls below 50%, then we print an error message along with the minimum p-value. If however more than 50% pass, then we print a success message, and the maximum p-value.